### PR TITLE
Bugfix #87 Update manifest identifier

### DIFF
--- a/Notebook.sketchplugin/Contents/Sketch/manifest.json
+++ b/Notebook.sketchplugin/Contents/Sketch/manifest.json
@@ -3,7 +3,7 @@
   "author" : "Marcos Vidal",
   "homepage": "http://marcosvid.al/sketch-notebook",
   "bundleVersion": 1,
-  "identifier" : "com.notebook",
+  "identifier" : "com.notebook.free",
   "version" : 0.3,
   "description" : "Documenting design made easy",
   "authorEmail" : "m@marcosvid.al",


### PR DESCRIPTION
Free version should use different manifest identifier than lite, pro, & premium to not conflict in Sketch Plugin Manager